### PR TITLE
Adds Angor Blocks Repository and Other Updates

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -116,6 +116,10 @@ class DatabaseMigration {
       this.getCreateAngorInvestmentsTableQuery(),
       await this.$checkIfTableExists('angor_investments')
     );
+    await this.$executeQuery(
+      this.getCreateAngorBlocksTableQuery(),
+      await this.$checkIfTableExists('angor_blocks')
+    );
     if (databaseSchemaVersion < 2 && this.statisticsAddedIndexed === false) {
       await this.$executeQuery(`CREATE INDEX added ON statistics (added);`);
       await this.updateToSchemaVersion(2);
@@ -574,7 +578,7 @@ class DatabaseMigration {
       await this.$executeQuery('ALTER TABLE `blocks_templates` ADD INDEX `version` (`version`)');
       await this.updateToSchemaVersion(67);
     }
-    
+
     if (databaseSchemaVersion < 68 && config.MEMPOOL.NETWORK === "liquid") {
       await this.$executeQuery('TRUNCATE TABLE elements_pegs');
       await this.$executeQuery('ALTER TABLE elements_pegs ADD PRIMARY KEY (txid, txindex);');
@@ -967,7 +971,7 @@ class DatabaseMigration {
       pegtxid varchar(65) NOT NULL,
       pegindex int(11) NOT NULL,
       pegblocktime int(11) unsigned NOT NULL,
-      PRIMARY KEY (txid, txindex), 
+      PRIMARY KEY (txid, txindex),
       FOREIGN KEY (bitcoinaddress) REFERENCES federation_addresses (bitcoinaddress)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8;`;
   }
@@ -1280,9 +1284,17 @@ class DatabaseMigration {
       transaction_status VARCHAR(13) NOT NULL,
       created_on_block INT(10),
       investor_npub CHAR(66) NOT NULL,
-      secret_hash CHAR(34) NOT NULL,
+      secret_hash CHAR(64) NOT NULL,
       is_seeder BOOLEAN NOT NULL,
       PRIMARY KEY (txid)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8;`;
+  }
+
+  private getCreateAngorBlocksTableQuery(): string {
+    return `CREATE TABLE IF NOT EXISTS angor_blocks (
+      block_height INT PRIMARY KEY,
+      block_hash CHAR(64) NOT NULL,
+      indexed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8;`;
   }
 

--- a/backend/src/indexer.ts
+++ b/backend/src/indexer.ts
@@ -17,6 +17,7 @@ import {
   AngorSupportedNetworks,
   AngorTransactionStatus,
 } from './angor/AngorTransactionDecoder';
+import AngorBlocksRepository from './repositories/AngorBlocksRepository';
 
 export interface CoreIndex {
   name: string;
@@ -32,7 +33,6 @@ class Indexer {
   private tasksRunning: { [key in TaskName]?: boolean; } = {};
   private tasksScheduled: { [key in TaskName]?: NodeJS.Timeout; } = {};
   private coreIndexes: CoreIndex[] = [];
-  private initialIndexingCompleted = false;
 
   public indexerIsRunning(): boolean {
     return this.indexerRunning;
@@ -51,7 +51,7 @@ class Indexer {
         synced: indexes[indexName].synced,
         best_block_height: indexes[indexName].best_block_height,
       };
-      logger.info(`Core index '${indexName}' is ${indexes[indexName].synced ? 'synced' : 'not synced'}. Best block height is ${indexes[indexName].best_block_height}`);      
+      logger.info(`Core index '${indexName}' is ${indexes[indexName].synced ? 'synced' : 'not synced'}. Best block height is ${indexes[indexName].best_block_height}`);
       updatedCoreIndexes.push(newState);
 
       if (indexName === 'coinstatsindex' && newState.synced === true) {
@@ -67,9 +67,9 @@ class Indexer {
 
   /**
    * Return the best block height if a core index is available, or 0 if not
-   * 
-   * @param name 
-   * @returns 
+   *
+   * @param name
+   * @returns
    */
   public isCoreIndexReady(name: string): CoreIndex | null {
     for (const index of this.coreIndexes) {
@@ -204,11 +204,8 @@ class Indexer {
 
       // Index transactions related to Angor projects.
       // This operation should be done once when initial indexing is complete.
-      if (!this.initialIndexingCompleted) {
-        this.initialIndexingCompleted = true;
+      await this.indexAngorTransactions();
 
-        await this.indexAngorTransactions();
-      }
 
       blocks.$classifyBlocks();
     } catch (e) {
@@ -243,6 +240,14 @@ class Indexer {
     );
 
     for (const indexedBlock of sortedBlocks) {
+      if (indexedBlock.height === 0) {
+        continue;
+      }
+
+      const alreadyIndexed = await AngorBlocksRepository.isBlockIndexed(indexedBlock.height, indexedBlock.hash);
+      if (alreadyIndexed) {
+        continue;
+      }
       // Transaction IDs in the block.
       const transactionIds = await bitcoinApi.$getTxIdsForBlock(
         indexedBlock.hash
@@ -278,6 +283,7 @@ class Indexer {
               });
           });
       }
+      await AngorBlocksRepository.$markBlockAsIndexed(indexedBlock.height, indexedBlock.hash);
     }
 
     logger.info('Indexing Angor transactions completed.');

--- a/backend/src/repositories/AngorBlocksRepository.ts
+++ b/backend/src/repositories/AngorBlocksRepository.ts
@@ -1,0 +1,35 @@
+import DB from '../database';
+import logger from "../logger";
+import { RowDataPacket } from "mysql2/typings/mysql";
+
+class AngorBlocksRepository {
+  public async $markBlockAsIndexed(blockHeight: number, blockHash: string): Promise<void> {
+    try {
+      await DB.query(
+        `INSERT INTO angor_blocks (block_height, block_hash) VALUES (?, ?)`, [blockHeight, blockHash])
+    } catch (error) {
+      logger.err(
+        'Error marking block as indexed. Reason: ' + (error instanceof Error ? error.message : error)
+      );
+    }
+  }
+
+  public async isBlockIndexed(blockHeight: number, blockHash: string): Promise<boolean> {
+    try {
+      const result = await DB.query(
+        `SELECT * FROM angor_blocks WHERE block_height = ? AND block_hash = ? LIMIT 1`, [blockHeight, blockHash]
+      );
+
+      const rows = result[0] as RowDataPacket;
+
+      return rows.length > 0;
+    } catch (error) {
+      logger.err(
+        'Error checking if block is indexed. Reason: ' + (error instanceof Error ? error.message : error)
+      );
+      return false;
+    }
+  }
+}
+
+export default new AngorBlocksRepository();

--- a/docker-angor-api/docker-compose.yml
+++ b/docker-angor-api/docker-compose.yml
@@ -50,9 +50,9 @@ services:
 
   mempool_api:
     container_name: mempool-api
-    image: eugenenostrdev/mempool-api:amd64-1.1.1
+    image: eugenenostrdev/mempool-api:amd64-1.1.6
     environment:
-      MEMPOOL_BACKEND: "electrum"
+      MEMPOOL_BACKEND: "esplora"
       ESPLORA_REST_API_URL: "http://mempool-electrs:3003"
       ELECTRUM_HOST: "mempool-electrs"
       ELECTRUM_PORT: "5001"
@@ -67,6 +67,8 @@ services:
       DATABASE_USERNAME: "mempool"
       DATABASE_PASSWORD: "mempool"
       STATISTICS_ENABLED: "true"
+      MEMPOOL_STDOUT_LOG_MIN_PRIORITY: "debug"
+      MEMPOOL_INDEXING_BLOCKS_AMOUNT: -1
       VIRTUAL_HOST: indexer.thedude.pro
       VIRTUAL_PORT: 8999
       VIRTUAL_PROTO: http
@@ -96,7 +98,7 @@ services:
     restart: unless-stopped
     stop_grace_period: 1m
     volumes:
-      - ./mysql/data:/var/lib/mysql
+      - memmpool_indexer:/var/lib/mysql
     networks:
       - mempoolnetwork
 

--- a/docker-angor-api/docker-compose.yml
+++ b/docker-angor-api/docker-compose.yml
@@ -50,7 +50,7 @@ services:
 
   mempool_api:
     container_name: mempool-api
-    image: eugenenostrdev/mempool-api:amd64-1.1.6
+    image: eugenenostrdev/mempool-api:amd64-1.1.7
     environment:
       MEMPOOL_BACKEND: "esplora"
       ESPLORA_REST_API_URL: "http://mempool-electrs:3003"


### PR DESCRIPTION
This PR updates docker-compose to be aligned with the docker-compose VM and adds the Angor Blocks Repository.

The purpose of the new table is to track every block that has been indexed by the Angor Indexer.

Previously, if the initial indexing gets interrupted for any reason, the process would not resume again. With the new mechanic, the process will run each time the indexer runs and compare every transaction to the already indexed transactions.

Note that this process is a bit 'wasteful', in a sense that it involves multiple, futile database queries each time an indexer runs. I will add a GitHub issue to add an improvement to avoid unneded database queries.

Finally, some database types have been updates to avoid errors that I saw in the logs where the length of strings that were written into the database exceeded the expected/pre-defined length.
