### PR TITLE
Disable E2E Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,110 +239,110 @@ jobs:
       - name: Build
         run: npm run build
         working-directory: ${{ matrix.node }}/${{ matrix.flavor }}/frontend
-        env: 
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MEMPOOL_CDN: 1
           VERBOSE: 1
-  
-  e2e:
-    if: "!contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')"
-    runs-on: "ubuntu-latest"
-    needs: frontend
-    strategy:
-      fail-fast: false
-      matrix:
-        module: ["mempool", "liquid"]
-        include:
-          - module: "mempool"
-            spec: |
-              cypress/e2e/mainnet/*.spec.ts
-              cypress/e2e/signet/*.spec.ts
-              cypress/e2e/testnet4/*.spec.ts
-          - module: "liquid"
-            spec: |
-              cypress/e2e/liquid/liquid.spec.ts
-              cypress/e2e/liquidtestnet/liquidtestnet.spec.ts
 
-    name: E2E tests for ${{ matrix.module }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          path: ${{ matrix.module }}
-
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20
-          cache: "npm"
-          cache-dependency-path: ${{ matrix.module }}/frontend/package-lock.json
-
-      - name: Restore cached mining pool assets
-        continue-on-error: true
-        id: cache-mining-pool-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            mining-pool-assets.zip
-          key: mining-pool-assets-cache
-  
-      - name: Restore cached promo video assets
-        continue-on-error: true
-        id: cache-promo-video-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            promo-video-assets.zip
-          key: promo-video-assets-cache
-
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: mining-pool-assets
-
-      - name: Unzip assets before building (src/resources)
-        run: unzip -o mining-pool-assets.zip -d ${{ matrix.module }}/frontend/src/resources/mining-pools
-
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: promo-video-assets
-
-      - name: Unzip assets before building (src/resources)
-        run: unzip -o promo-video-assets.zip -d ${{ matrix.module }}/frontend/src/resources/promo-video
-      
-      - name: Chrome browser tests (${{ matrix.module }})
-        uses: cypress-io/github-action@v5
-        with:
-          tag: ${{ github.event_name }}
-          working-directory: ${{ matrix.module }}/frontend
-          build: npm run config:defaults:${{ matrix.module }}
-          start: npm run start:local-staging
-          wait-on: "http://localhost:4200"
-          wait-on-timeout: 120
-          record: true
-          parallel: true
-          spec: ${{ matrix.spec }}
-          group: Tests on Chrome (${{ matrix.module }})
-          browser: "chrome"
-          ci-build-id: "${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}"
-        env:
-          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
+#  e2e:
+#    if: "!contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')"
+#    runs-on: "ubuntu-latest"
+#    needs: frontend
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        module: ["mempool", "liquid"]
+#        include:
+#          - module: "mempool"
+#            spec: |
+#              cypress/e2e/mainnet/*.spec.ts
+#              cypress/e2e/signet/*.spec.ts
+#              cypress/e2e/testnet4/*.spec.ts
+#          - module: "liquid"
+#            spec: |
+#              cypress/e2e/liquid/liquid.spec.ts
+#              cypress/e2e/liquidtestnet/liquidtestnet.spec.ts
+#
+#    name: E2E tests for ${{ matrix.module }}
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#        with:
+#          path: ${{ matrix.module }}
+#
+#      - name: Setup node
+#        uses: actions/setup-node@v3
+#        with:
+#          node-version: 20
+#          cache: "npm"
+#          cache-dependency-path: ${{ matrix.module }}/frontend/package-lock.json
+#
+#      - name: Restore cached mining pool assets
+#        continue-on-error: true
+#        id: cache-mining-pool-restore
+#        uses: actions/cache/restore@v4
+#        with:
+#          path: |
+#            mining-pool-assets.zip
+#          key: mining-pool-assets-cache
+#
+#      - name: Restore cached promo video assets
+#        continue-on-error: true
+#        id: cache-promo-video-restore
+#        uses: actions/cache/restore@v4
+#        with:
+#          path: |
+#            promo-video-assets.zip
+#          key: promo-video-assets-cache
+#
+#      - name: Download artifact
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: mining-pool-assets
+#
+#      - name: Unzip assets before building (src/resources)
+#        run: unzip -o mining-pool-assets.zip -d ${{ matrix.module }}/frontend/src/resources/mining-pools
+#
+#      - name: Download artifact
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: promo-video-assets
+#
+#      - name: Unzip assets before building (src/resources)
+#        run: unzip -o promo-video-assets.zip -d ${{ matrix.module }}/frontend/src/resources/promo-video
+#
+#      - name: Chrome browser tests (${{ matrix.module }})
+#        uses: cypress-io/github-action@v5
+#        with:
+#          tag: ${{ github.event_name }}
+#          working-directory: ${{ matrix.module }}/frontend
+#          build: npm run config:defaults:${{ matrix.module }}
+#          start: npm run start:local-staging
+#          wait-on: "http://localhost:4200"
+#          wait-on-timeout: 120
+#          record: true
+#          parallel: true
+#          spec: ${{ matrix.spec }}
+#          group: Tests on Chrome (${{ matrix.module }})
+#          browser: "chrome"
+#          ci-build-id: "${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}"
+#        env:
+#          COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
+#          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#          CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
 
   validate_docker_json:
     if: "!contains(github.event.pull_request.labels.*.name, 'ops') && !contains(github.head_ref, 'ops/')"
     runs-on: "ubuntu-latest"
     name: Validate generated backend Docker JSON
 
-    steps: 
+    steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           path: docker
-      
+
       - name: Install jq
         run: sudo apt-get install jq -y
 


### PR DESCRIPTION
It has been observed that the E2E tests have been failing for every open PR over the past couple of days.

I have run the tests locally and the reason the tests start to timeout is we get the 429 error code, i.e. too many requests. The tests are configured to proxy requests to the official mempool staging environment and once we hit a certain number of requests, we start getting error response.

I recommend to disable the e2e tests until we deploy our own staging environment, if the need arises.
