### PR TITLE
Increase Esplora Timeout

### DIFF
--- a/docker-angor-api/docker-compose.yml
+++ b/docker-angor-api/docker-compose.yml
@@ -54,6 +54,7 @@ services:
     environment:
       MEMPOOL_BACKEND: "esplora"
       ESPLORA_REST_API_URL: "http://mempool-electrs:3003"
+      ESPLORA_REQUEST_TIMEOUT: "50000"
       ELECTRUM_HOST: "mempool-electrs"
       ELECTRUM_PORT: "5001"
       ELECTRUM_TLS_ENABLED: "false"


### PR DESCRIPTION
It has been observed that the address endpoint in the active VM deploy resulted in the 500 response. After some investigation, I have established that the error is due to the backend timing out while waiting for a response from Esplora.

Therefore, this PR increases the timeout to 50000.

Note that this particular error is an edge case. The timeout has been observed when querying what looks like a coinbase address which has hundreds of transactions. When querying regular addresses,no response lag is observed.
