### PR TITLE
#245 Enable POST Transaction Endpoint

### DIFF
--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -325,7 +325,7 @@ class ElectrsApi implements AbstractBitcoinApi {
   }
 
   $sendRawTransaction(rawTransaction: string): Promise<string> {
-    throw new Error('Method not implemented.');
+    return this.failoverRouter.$post<string>('/tx', rawTransaction);
   }
 
   $testMempoolAccept(rawTransactions: string[], maxfeerate?: number): Promise<TestMempoolAcceptResult[]> {

--- a/backend/src/api/bitcoin/esplora-api.ts
+++ b/backend/src/api/bitcoin/esplora-api.ts
@@ -325,7 +325,7 @@ class ElectrsApi implements AbstractBitcoinApi {
   }
 
   $sendRawTransaction(rawTransaction: string): Promise<string> {
-    return this.failoverRouter.$post<string>('/tx', rawTransaction);
+    return this.failoverRouter.$post<string>('/tx', rawTransaction, 'string');
   }
 
   $testMempoolAccept(rawTransactions: string[], maxfeerate?: number): Promise<TestMempoolAcceptResult[]> {


### PR DESCRIPTION
This PR implements/enables the POST endpoint to create transactions through Mempool.

Fixes [#245](https://github.com/block-core/angor/issues/245).

Even though the endpoint was added in the `bitcoin.routes` file, the `Esplora API` interface that was called during the execution of the request was not implemented.

I checked that the Esplora API itself `(electrs)` has a working endpoint that the Mempool backend calls.

The full flow still needs to be tested out - the Angor Testnet UI that I previously used to obtain Signet funds is currently not working.
