### PR TITLE
Added liquid testnet settings for running the Liquid Mempool

### DIFF
--- a/docker/docker-compose-liquid.yml
+++ b/docker/docker-compose-liquid.yml
@@ -1,0 +1,86 @@
+version: "3.7"
+
+services:
+  web:
+    environment:
+      FRONTEND_HTTP_PORT: "8080"
+      BACKEND_MAINNET_HTTP_HOST: "127.0.0.1"
+      BACKEND_MAINNET_HTTP_PORT: "8999"
+      MAINNET_ENABLED: "false"
+      LIQUID_ENABLED: "true"
+      LIQUID_TESTNET_ENABLED: "true"
+      ROOT_NETWORK: "liquidtestnet"
+      BASE_MODULE: "liquid"
+      LIQUID_WEBSITE_URL: "http://localhost:8081"
+    image: blockcore/mempool-frontend:latest
+    user: "1000:1000"
+    restart: on-failure
+    stop_grace_period: 1m
+    command: "./wait-for 127.0.0.1:3306 --timeout=720 -- nginx -g 'daemon off;'"
+    network_mode: host
+    depends_on:
+      - api
+      - db
+
+  api:
+    environment:
+      MEMPOOL_NETWORK: "liquidtestnet"
+      MEMPOOL_BACKEND: "none"
+      MEMPOOL_ENABLED: "true"
+      
+      # Esplora configuration (connecting to the local electrs)
+      ESPLORA_REST_API_URL: "http://127.0.0.1:3001"
+      ESPLORA_REQUEST_TIMEOUT: "10000"
+      ESPLORA_FALLBACK_TIMEOUT: "10000"
+      
+      # Elements Core RPC configuration
+      CORE_RPC_HOST: "127.0.0.1"
+      CORE_RPC_PORT: "18891"
+      CORE_RPC_USERNAME: "user"
+      CORE_RPC_PASSWORD: "password"
+      CORE_RPC_TIMEOUT: "60000"
+      
+      DATABASE_ENABLED: "true"
+      DATABASE_HOST: "127.0.0.1"
+      DATABASE_PORT: "3306"
+      DATABASE_DATABASE: "mempool"
+      DATABASE_USERNAME: "mempool"
+      DATABASE_PASSWORD: "mempool"
+      
+      STATISTICS_ENABLED: "true"
+      MEMPOOL_STDOUT_LOG_MIN_PRIORITY: "debug"
+      MEMPOOL_INDEXING_BLOCKS_AMOUNT: "8640"
+      MEMPOOL_BLOCKS_SUMMARIES_INDEXING: "true"
+      
+      MEMPOOL_CACHE_ENABLED: "true"
+      MEMPOOL_CACHE_DIR: "/backend/cache"
+      MEMPOOL_CLEAR_PROTECTION_MINUTES: "20"
+      MEMPOOL_RECOMMENDED_FEE_PERCENTILE: "50"
+      MEMPOOL_BLOCK_WEIGHT_UNITS: "4000000"
+      MEMPOOL_INITIAL_BLOCKS_AMOUNT: "8"
+      MEMPOOL_MEMPOOL_BLOCKS_AMOUNT: "8"
+      
+    image: blockcore/mempool-backend:latest
+    user: "1000:1000"
+    restart: on-failure
+    stop_grace_period: 1m
+    command: "./wait-for-it.sh 127.0.0.1:3306 --timeout=720 --strict -- ./start.sh"
+    network_mode: host
+    volumes:
+      - ./data:/backend/cache
+    depends_on:
+      - db
+
+  db:
+    environment:
+      MYSQL_DATABASE: "mempool"
+      MYSQL_USER: "mempool"
+      MYSQL_PASSWORD: "mempool"
+      MYSQL_ROOT_PASSWORD: "admin"
+    image: mariadb:10.5.21
+    user: "1000:1000"
+    restart: on-failure
+    stop_grace_period: 1m
+    network_mode: host
+    volumes:
+      - ./mysql/data:/var/lib/mysql


### PR DESCRIPTION
### Description

Added Docker setup for running the Liquid Testnet Mempool

The elements.conf file used for starting the Elements Core (liquidtestnet) is -- 

```bash
chain=liquidtestnet

[liquidtestnet]
daemon=1
server=1
listen=1
txindex=1

addnode=liquid.network:18444
addnode=liquid-testnet.blockstream.com:18891
addnode=liquidtestnet.com:18891

rpcuser=user
rpcpassword=password
rpcport=18891
rpcbind=0.0.0.0
rpcallowip=0.0.0.0/0
```
Used the romanz/electrs to spin up the electrs server and the liquid mempool

```bash
./target/release/electrs \
  --daemon-rpc-addr 127.0.0.1:18891 \
  --cookie user:password \
  --daemon-dir /home/ritankar/.elements/liquidtestnet \
  --network liquidtestnet \
  --parent-network testnet \
  --db-dir /home/ritankar/.electrs/liquidtestnet-db \
  --electrum-rpc-addr 127.0.0.1:51001 \
  --lightmode \
  --jsonrpc-import \
  -vvvv
```
