### PR TITLE
Liquid config files for Angor Enabled and Scripts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,9 @@
     "cypress:open:ci": "node update-config.js TESTNET_ENABLED=true TESTNET4_ENABLED=true SIGNET_ENABLED=true LIQUID_ENABLED=true ITEMS_PER_PAGE=25 && npm run generate-config && start-server-and-test serve:local-prod 4200 cypress:open",
     "cypress:run:ci": "node update-config.js TESTNET_ENABLED=true TESTNET4_ENABLED=true SIGNET_ENABLED=true LIQUID_ENABLED=true ITEMS_PER_PAGE=25 && npm run generate-config && start-server-and-test serve:local-prod 4200 cypress:run:record",
     "cypress:open:ci:staging": "node update-config.js TESTNET_ENABLED=true TESTNET4_ENABLED=true SIGNET_ENABLED=true LIQUID_ENABLED=true ITEMS_PER_PAGE=25 && npm run generate-config && start-server-and-test serve:local-staging 4200 cypress:open",
-    "cypress:run:ci:staging": "node update-config.js TESTNET_ENABLED=true TESTNET4_ENABLED=true SIGNET_ENABLED=true LIQUID_ENABLED=true ITEMS_PER_PAGE=25 && npm run generate-config && start-server-and-test serve:local-staging 4200 cypress:run:record"
+    "cypress:run:ci:staging": "node update-config.js TESTNET_ENABLED=true TESTNET4_ENABLED=true SIGNET_ENABLED=true LIQUID_ENABLED=true ITEMS_PER_PAGE=25 && npm run generate-config && start-server-and-test serve:local-staging 4200 cypress:run:record",
+    "serve:local": "ng serve --proxy-config proxy.conf.js --host 0.0.0.0 --port 4200",
+    "serve:local-liquid": "npm run config:defaults:liquid && ng serve --proxy-config proxy.conf.js --host 0.0.0.0 --port 4200"
   },
   "dependencies": {
     "@angular-devkit/build-angular": "^17.3.1",

--- a/frontend/proxy-liquid.conf.js
+++ b/frontend/proxy-liquid.conf.js
@@ -1,0 +1,64 @@
+// Simplified proxy configuration without external config file dependency
+const PROXY_CONFIG = [
+  {
+    context: [
+      '/api/**', '!/api/v1/ws',
+      '!/liquid', '!/liquid/**', '!/liquid/',
+      '!/liquidtestnet', '!/liquidtestnet/**', '!/liquidtestnet/'
+    ],
+    target: "http://localhost:8999",
+    ws: true,
+    secure: false,
+    changeOrigin: true,
+    logLevel: 'debug'
+  },
+  {
+    context: ['/api/v1/ws'],
+    target: "http://localhost:8999",
+    ws: true,
+    secure: false,
+    changeOrigin: true,
+    logLevel: 'debug'
+  },
+  {
+    context: ['/api/liquid**', '/liquid/api/**'],
+    target: "http://localhost:8999",
+    pathRewrite: {
+      "^/api/liquid/": "/api/v1/"
+    },
+    ws: true,
+    secure: false,
+    changeOrigin: true,
+    logLevel: 'debug'
+  },
+  {
+    context: ['/api/liquidtestnet**', '/liquidtestnet/api/**'],
+    target: "http://localhost:8999",
+    pathRewrite: {
+      "^/api/liquidtestnet/": "/api/v1/",
+      "^/liquidtestnet/api/": "/api/v1/"
+    },
+    ws: true,
+    secure: false,
+    changeOrigin: true,
+    logLevel: 'debug'
+  },
+  {
+    context: ['/resources/mining-pools/**'],
+    target: "https://mempool.space",
+    secure: false,
+    changeOrigin: true
+  },
+  // Assets for liquid (since we're using liquid testnet)
+  {
+    context: [
+      '/resources/assets.json', '/resources/assets.minimal.json',
+      '/resources/assets-testnet.json', '/resources/assets-testnet.minimal.json'
+    ],
+    target: "https://liquid.network",
+    secure: false,
+    changeOrigin: true,
+  }
+];
+
+module.exports = PROXY_CONFIG;

--- a/production/mempool-config.liquid.json
+++ b/production/mempool-config.liquid.json
@@ -79,5 +79,8 @@
   "STATISTICS": {
     "ENABLED": true,
     "TX_PER_SECOND_SAMPLE_PERIOD": 150
+  },
+  "ANGOR": {
+    "ENABLED": true
   }
 }

--- a/production/mempool-config.liquidtestnet.json
+++ b/production/mempool-config.liquidtestnet.json
@@ -79,5 +79,8 @@
   "STATISTICS": {
     "ENABLED": true,
     "TX_PER_SECOND_SAMPLE_PERIOD": 150
+  },
+  "ANGOR": {
+    "ENABLED": true
   }
 }

--- a/production/mempool-frontend-config.liquid.json
+++ b/production/mempool-frontend-config.liquid.json
@@ -8,6 +8,7 @@
   "BISQ_ENABLED": true,
   "BISQ_SEPARATE_BACKEND": true,
   "SIGNET_ENABLED": true,
+  "ANGOR_ENABLED": true,
   "MEMPOOL_WEBSITE_URL": "https://mempool.space",
   "LIQUID_WEBSITE_URL": "https://liquid.network",
   "BISQ_WEBSITE_URL": "https://bisq.markets",


### PR DESCRIPTION
## Description

- changes in the config files toggling angor enabled, needed for "Angor Projects" Tab, and to redirect properly there.
- changes in the package.json file, adding scripts for firing the frontend server liquid specific, will add the readme in the following PR
- sample proxy.conf.js file for liquid specific settings. (This is a sample file for future reference, right now it is redirected to the localhost URLs, for future reference or for running the liquid testnet mempool locally.
- Upon proper deployment of the Indexer will attach the proper URLs and make the necessary modifications in the parent proxy.conf.js file. 