### PR TITLE
used parameterized queries to handle undefined values due the usage of string-interpolation

### DIFF
--- a/backend/src/repositories/AngorProjectRepository.ts
+++ b/backend/src/repositories/AngorProjectRepository.ts
@@ -54,25 +54,34 @@ class AngorProjectRepository {
   ): Promise<void> {
     try {
       const query = `INSERT INTO angor_projects
-          (
-            id,
-            address_on_fee_output,
-            creation_transaction_status,
-            created_on_block,
-            txid,
-            founder_key,
-            nostr_event_id
-          )
-          VALUES ('${id}', '${addressOnFeeOutput}', '${transactionStatus}', '${createdOnBlock}', '${txid}', '${founderKey}', '${nostrEventId}')
-          ON DUPLICATE KEY UPDATE
-            creation_transaction_status = '${transactionStatus}'
-        `;
+        (
+          id,
+          address_on_fee_output,
+          creation_transaction_status,
+          created_on_block,
+          txid,
+          founder_key,
+          nostr_event_id
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON DUPLICATE KEY UPDATE
+          creation_transaction_status = ?
+      `;
 
-      await DB.query(query);
+      await DB.query(query, [
+        id,
+        addressOnFeeOutput,
+        transactionStatus,
+        createdOnBlock || null,
+        txid,
+        founderKey,
+        nostrEventId || null,
+        transactionStatus
+      ]);
     } catch (e: any) {
       logger.err(
         `Cannot save Angor project into db. Reason: ` +
-          (e instanceof Error ? e.message : e)
+        (e instanceof Error ? e.message : e)
       );
 
       throw e;


### PR DESCRIPTION
- using string-interpolation for query caused sql syntax issue, as `undefined` is not a proper sql keyword
- with parameterized-queries, `undefined` is converted to `null` which prevents sql-injection attacks too
- set default values to `null`
- this fixes: ``ERR: Cannot save Angor project into db. Reason: Incorrect integer value: 'undefined' for column `mempool_angor`.`angor_projects`.`created_on_block` at row``